### PR TITLE
Add X-Crawlera-Client header

### DIFF
--- a/scrapy_crawlera/middleware.py
+++ b/scrapy_crawlera/middleware.py
@@ -148,6 +148,7 @@ class CrawleraMiddleware(object):
         return basic_auth_header(self.apikey, '')
 
     def process_request(self, request, spider):
+        from scrapy_crawlera import __version__
         if self._is_enabled_for_request(request):
             self._set_crawlera_default_headers(request)
             request.meta['proxy'] = self.url
@@ -155,6 +156,7 @@ class CrawleraMiddleware(object):
             request.headers['Proxy-Authorization'] = self._proxyauth
             if self.job_id:
                 request.headers['X-Crawlera-Jobid'] = self.job_id
+            request.headers['X-Crawlera-Client'] = 'scrapy-crawlera/%s' % __version__
             self.crawler.stats.inc_value('crawlera/request')
             self.crawler.stats.inc_value('crawlera/request/method/%s' % request.method)
         else:

--- a/tests/test_crawlera.py
+++ b/tests/test_crawlera.py
@@ -14,7 +14,7 @@ from scrapy.resolver import dnscache
 from scrapy.exceptions import ScrapyDeprecationWarning
 from twisted.internet.error import ConnectionRefusedError, ConnectionDone
 
-from scrapy_crawlera import CrawleraMiddleware
+from scrapy_crawlera import CrawleraMiddleware, __version__
 import os
 
 from scrapy_crawlera.utils import exp_backoff
@@ -895,3 +895,15 @@ class CrawleraMiddlewareTestCase(TestCase):
         mw.process_request(req, self.spider)
         assert mw.process_request(req, self.spider) is None
         self.assertEqual(req.headers['X-Crawlera-Profile'], b'desktop')
+
+    def test_client_header(self):
+        self.spider.crawlera_enabled = True
+        crawler = self._mock_crawler(self.spider, self.settings)
+        mw = self.mwcls.from_crawler(crawler)
+        mw.open_spider(self.spider)
+        req = Request('http://www.scrapytest.org')
+        self.assertEqual(mw.process_request(req, self.spider), None)
+        self.assertEqual(
+            req.headers.get('X-Crawlera-Client').decode('utf-8'),
+            'scrapy-crawlera/%s' % __version__
+        )


### PR DESCRIPTION
Not sure about `import` inside `process_request()`
Maybe makes sense to move `__version__` from `__init__.py` to `middleware.py`?